### PR TITLE
Swap `println!` with log macros

### DIFF
--- a/src/bin/dmapembed.rs
+++ b/src/bin/dmapembed.rs
@@ -181,8 +181,8 @@ fn parse_dmap_group(
 
 #[allow(clippy::range_zip_with_len)]
 pub fn main() {
-    println!("initializing default logger from environment ...");
     env_logger::Builder::from_default_env().init();
+    log::info!("initializing default logger from environment ...");
     log::info!("logger initialized from default environment");
     //
     let hnswparams: HnswParams;
@@ -317,7 +317,7 @@ pub fn main() {
             }
             _ => {
                 log::error!("parsing hnsw command failed");
-                println!("exiting with error {}", res.err().as_ref().unwrap());
+                log::error!("exiting with error {}", res.err().as_ref().unwrap());
                 //  log::error!("exiting with error {}", res.err().unwrap());
                 std::process::exit(1);
             }
@@ -338,7 +338,7 @@ pub fn main() {
         }
         _ => {
             log::error!("parsing embed cmd failed");
-            println!("exiting with error {}", res.err().as_ref().unwrap());
+            log::error!("exiting with error {}", res.err().as_ref().unwrap());
             //  log::error!("exiting with error {}", res.err().unwrap());
             std::process::exit(1);
         }
@@ -390,7 +390,7 @@ pub fn main() {
     if dmapparams.get_hlayer() == 0 {
         let kgraph = get_kgraph_with_distname(&data_with_id, &hnswparams, nb_layer);
         let cpu_time: Duration = cpu_start.elapsed();
-        println!(
+        log::info!(
             " graph construction sys time(s) {:?} cpu time {:?}",
             sys_now.elapsed().unwrap().as_secs(),
             cpu_time.as_secs()

--- a/src/bin/embed.rs
+++ b/src/bin/embed.rs
@@ -175,8 +175,8 @@ fn parse_embed_group(
 
 #[allow(clippy::range_zip_with_len)]
 pub fn main() {
-    println!("\n ************** initializing logger *****************\n");
     env_logger::Builder::from_default_env().init();
+    log::info!("\n ************** initializing logger *****************\n");
     log::info!("logger initialized from default environment");
     //
     let hnswparams: HnswParams;
@@ -330,7 +330,7 @@ pub fn main() {
             }
             _ => {
                 log::error!("parsing hnsw command failed");
-                println!("exiting with error {}", res.err().as_ref().unwrap());
+                log::error!("exiting with error {}", res.err().as_ref().unwrap());
                 //  log::error!("exiting with error {}", res.err().unwrap());
                 std::process::exit(1);
             }
@@ -351,7 +351,7 @@ pub fn main() {
         }
         _ => {
             log::error!("parsing embed cmd failed");
-            println!("exiting with error {}", res.err().as_ref().unwrap());
+            log::error!("exiting with error {}", res.err().as_ref().unwrap());
             //  log::error!("exiting with error {}", res.err().unwrap());
             std::process::exit(1);
         }
@@ -403,7 +403,7 @@ pub fn main() {
         let hubdim = true; // to get hubness and intrinsic dimension info
         let kgraph = get_kgraph_with_distname(&data_with_id, &hnswparams, nb_layer, hubdim);
         let cpu_time: Duration = cpu_start.elapsed();
-        println!(
+        log::info!(
             " graph construction sys time(s) {:?} cpu time {:?}",
             sys_now.elapsed().unwrap().as_secs(),
             cpu_time.as_secs()
@@ -482,7 +482,7 @@ where
         let sys_now = SystemTime::now();
         let dim_stat = kgraph.estimate_intrinsic_dim(sampling_size);
         let cpu_time: Duration = cpu_start.elapsed();
-        println!(
+        log::info!(
             "\n dimension estimation sys time(ms) : {:.3e},  cpu time(ms) {:.3e}\n",
             sys_now.elapsed().unwrap().as_millis(),
             cpu_time.as_millis()
@@ -495,7 +495,7 @@ where
                 dim_stat.0,
                 dim_stat.1
             );
-            println!(
+            log::info!(
                 " dimension estimation with nbpoints : {}, dim : {:.3e}, sigma = {:.3e}",
                 sampling_size, dim_stat.0, dim_stat.1
             );
@@ -504,7 +504,7 @@ where
         let hubness = hubness::Hubness::new(&kgraph);
         let s3_hubness = hubness.get_standard3m();
         log::info!("\n graph hubness estimation : {:.3e}", s3_hubness);
-        println!("\n graph hubness estimation : {:.3e} \n", s3_hubness);
+        log::info!("\n graph hubness estimation : {:.3e} \n", s3_hubness);
         let _histo = hubness.get_hubness_histogram();
         let _kgraph_stats = kgraph.get_kraph_stats();
     }

--- a/src/diffmaps.rs
+++ b/src/diffmaps.rs
@@ -89,7 +89,7 @@ impl DiffusionParams {
     /// natural values are 0. , 1/2 and 1.
     pub fn set_alfa(&mut self, alfa: f32) {
         if !(-1.01..=1.).contains(&alfa) {
-            println!("not changing alfa, alfa should be in [-1. , 1.] ");
+            log::warn!("not changing alfa, alfa should be in [-1. , 1.] ");
             return;
         }
         self.alfa = alfa;
@@ -100,7 +100,7 @@ impl DiffusionParams {
         if (-1.01..=0.).contains(&beta) {
             self.beta = beta;
         } else {
-            println!("not changing beta, beta should be in -1,0 Usual values are 0. -0.5 see doc ");
+            log::warn!("not changing beta, beta should be in -1,0 Usual values are 0. -0.5 see doc ");
         }
     }
 
@@ -595,7 +595,7 @@ impl DiffusionMaps {
             .collect();
         // collect scales quantiles
         let scales_q = self.get_quantiles("scales quantiles first pass", &local_scales);
-        println!();
+        log::debug!("");
         // we keep local scale to possible kernel weighting
         //
         // now we have scales we can remap edge length to weights.
@@ -707,7 +707,7 @@ impl DiffusionMaps {
         for q in values {
             quant_densities.insert((*q).into());
         }
-        println!(
+        log::debug!(
             "quantiles at 0.01 : {:.2e}, 0.05 : {:.2e} , 0.5 :  {:.2e}, 0.95 : {:.2e}, 0.99 : {:.2e}",
             quant_densities.query(0.01).unwrap().1,
             quant_densities.query(0.05).unwrap().1,
@@ -715,7 +715,7 @@ impl DiffusionMaps {
             quant_densities.query(0.95).unwrap().1,
             quant_densities.query(0.99).unwrap().1
         );
-        println!();
+        log::debug!("");
         //
         quant_densities
     }
@@ -1212,7 +1212,7 @@ mod tests {
             panic!("dmap_fashion failed");
         };
         //
-        println!(
+        log::info!(
             " dmap embed time {:.2e} s, cpu time : {}",
             sys_now.elapsed().unwrap().as_secs(),
             cpu_start.elapsed().as_secs()
@@ -1288,7 +1288,7 @@ mod tests {
             panic!("dmap_fashion failed");
         };
         //
-        println!(
+        log::info!(
             " dmap embed time {:.2e} s, cpu time : {}",
             sys_now.elapsed().unwrap().as_secs(),
             cpu_start.elapsed().as_secs()

--- a/src/embedder.rs
+++ b/src/embedder.rs
@@ -192,7 +192,7 @@ where
             log::error!("Embedder::h_embed first step failed");
             return res_first;
         }
-        println!(
+        log::info!(
             " first step embedding sys time(ms) {:.2e} cpu time(ms) {:.2e}",
             sys_start.elapsed().unwrap().as_millis(),
             cpu_start.elapsed().as_millis()
@@ -210,7 +210,7 @@ where
         // use projection to initialize large graph
         let quant = graph_projection.get_projection_distance_quant();
         if quant.count() > 0 {
-            println!(
+            log::debug!(
                 " projection distance quantile at 0.05 : {:.2e} , 0.5 :  {:.2e}, 0.95 : {:.2e}, 0.99 : {:.2e}",
                 quant.query(0.05).unwrap().1,
                 quant.query(0.5).unwrap().1,
@@ -252,7 +252,7 @@ where
         let embedding_res =
             self.entropy_optimize(&self.parameters, self.initial_embedding.as_ref().unwrap());
         //
-        println!(
+        log::info!(
             " first + second step embedding sys time(s) {:.2e} cpu time(s) {:.2e}",
             sys_start.elapsed().unwrap().as_secs(),
             cpu_start.elapsed().as_secs()
@@ -314,7 +314,7 @@ where
                 );
             }
 
-            println!(
+            log::info!(
                 " dmap initialization sys time(ms) {:.2e} cpu time(ms) {:.2e}",
                 sys_start.elapsed().unwrap().as_millis(),
                 cpu_start.elapsed().as_millis()
@@ -644,16 +644,16 @@ where
             .fold(0, |acc, x| if *x == 0 { acc + 1 } else { acc });
         let mean_nbmatch: f64 = nodes_match.iter().sum::<usize>() as f64
             / (nodes_match.len() - nb_without_match) as f64;
-        println!("\n\n a guess at quality ");
-        println!(
+        log::info!("\n\n a guess at quality ");
+        log::info!(
             "  neighbourhood size used in embedding : {}",
             self.get_kgraph_nbng()
         );
-        println!(
+        log::info!(
             "  nb neighbourhoods without a match : {},  mean number of neighbours conserved when match : {:.3e}",
             nb_without_match, mean_nbmatch
         );
-        println!(
+        log::info!(
             "  embedded radii quantiles at 0.05 : {:.2e} , 0.25 : {:.2e}, 0.5 :  {:.2e}, 0.75 : {:.2e}, 0.85 : {:.2e}, 0.95 : {:.2e} \n",
             embedded_radii.query(0.05).unwrap().1,
             embedded_radii.query(0.25).unwrap().1,
@@ -665,12 +665,12 @@ where
         //
         // The smaller the better!
         // we give quantiles on ratio : distance of neighbours in origin space / distance of last neighbour in embedded space
-        println!("\n statistics on conservation of neighborhood (of size nbng)");
-        println!("  neighbourhood size used in target space : {}", nbng);
-        println!(
+        log::info!("\n statistics on conservation of neighborhood (of size nbng)");
+        log::info!("  neighbourhood size used in target space : {}", nbng);
+        log::info!(
             "  quantiles on ratio : distance in embedded space of neighbours of origin space / distance of last neighbour in embedded space"
         );
-        println!(
+        log::info!(
             "  quantiles at 0.05 : {:.2e} , 0.25 : {:.2e}, 0.5 :  {:.2e}, 0.75 : {:.2e}, 0.85 : {:.2e}, 0.95 : {:.2e} \n",
             ratio_dist_q.query(0.05).unwrap().1,
             ratio_dist_q.query(0.25).unwrap().1,
@@ -681,15 +681,15 @@ where
         );
 
         let median_ratio = ratio_dist_q.query(0.5).unwrap().1;
-        println!(
+        log::info!(
             "\n quality index: ratio of distance to neighbours in origin space / distance to last neighbour in embedded space"
         );
-        println!(
+        log::info!(
             "  neighborhood are conserved in radius multiplied by median  : {:.2e}, mean {:.2e} ",
             median_ratio,
             mean_ratio.0 / mean_ratio.1 as f64
         );
-        println!();
+        log::info!("");
         //
         let mut csv_dist = Writer::from_path("first_dist.csv").unwrap();
         let _res = write_csv_labeled_array2(
@@ -771,7 +771,7 @@ where
         let start = ProcessTime::now();
         let initial_ce = ce_optimization.ce_compute_threaded();
         let cpu_time: Duration = start.elapsed();
-        println!(
+        log::info!(
             " initial cross entropy value {:.2e},  in time {:?}",
             initial_ce, cpu_time
         );
@@ -802,13 +802,13 @@ where
             //            let cpu_time: Duration = start.elapsed();
             //            log::debug!("ce after grad iteration time(ms) {:.2e} grad iter {:.2e}",  cpu_time.as_millis(), ce_optimization.ce_compute_threaded());
         }
-        println!(
+        log::info!(
             " gradient iterations sys time(s) {:.2e} , cpu_time(s) {:.2e}",
             sys_start.elapsed().unwrap().as_secs(),
             cpu_start.elapsed().as_secs()
         );
         let final_ce = ce_optimization.ce_compute_threaded();
-        println!(" final cross entropy value {:.2e}", final_ce);
+        log::info!(" final cross entropy value {:.2e}", final_ce);
         // return reindexed data (if possible)
         let dim = self.get_asked_dimension();
         let nbrow = self.get_nb_nodes();
@@ -900,14 +900,14 @@ where
         for s in &embedded_scales {
             scales_q.insert(*s);
         }
-        println!(
+        log::debug!(
             "\n\n embedded scales quantiles at 0.05 : {:.2e} , 0.5 :  {:.2e}, 0.95 : {:.2e}, 0.99 : {:.2e}",
             scales_q.query(0.05).unwrap().1,
             scales_q.query(0.5).unwrap().1,
             scales_q.query(0.95).unwrap().1,
             scales_q.query(0.99).unwrap().1
         );
-        println!();
+        log::debug!("");
         //
         EntropyOptim {
             node_params,

--- a/src/fromhnsw/hubness.rs
+++ b/src/fromhnsw/hubness.rs
@@ -122,7 +122,7 @@ where
         }
         // display result
         if nb_out_histo > 0 {
-            println!(
+            log::warn!(
                 "number of too large values : {}, maximum value : {}",
                 nb_out_histo, max_value
             );
@@ -133,11 +133,11 @@ where
             .map(|f| histo.value_at_quantile(*f))
             .collect::<Vec<u64>>();
         //
-        println!("\n hubness quantiles : ");
-        println!("======================");
-        println!("quantiles : {:?}", quantiles);
-        println!("thresholds : {:?}", thresholds);
-        println!("\n");
+        log::info!("\n hubness quantiles : ");
+        log::info!("======================");
+        log::info!("quantiles : {:?}", quantiles);
+        log::info!("thresholds : {:?}", thresholds);
+        log::info!("\n");
         //
         Ok(histo)
     } // end of get_hubness_histogram

--- a/src/fromhnsw/kgproj.rs
+++ b/src/fromhnsw/kgproj.rs
@@ -75,7 +75,7 @@ where
                 "KGraphProjection::new, layer argument greater than nb_layer!!, layer : {}",
                 layer
             );
-            println!(
+            log::error!(
                 "KGraphProjection::new, layer argument greater than nb_layer!!, layer : {}",
                 layer
             );
@@ -90,7 +90,6 @@ where
         }
         if nb_point_to_collect == 0 {
             log::error!("!!!!!!!!!!!! KGraphProjection cannot collect points !!!!!!!!!!!!!, check layer argument");
-            println!("!!!!!!!!!!!! KGraphProjection cannot collect points !!!!!!!!!!!!!, check layer argument");
             std::process::exit(1);
         }
         //
@@ -506,7 +505,7 @@ mod tests {
         let dim = 30;
         let knbn = 10;
         //
-        println!("\n\n test_graph_projection nb_elem {:?}", nb_elem);
+        log::debug!("\n\n test_graph_projection nb_elem {:?}", nb_elem);
         //
         let data = gen_rand_data_f32(nb_elem, dim);
         let data_with_id: Vec<(&Vec<f32>, usize)> = data.iter().zip(0..data.len()).collect();

--- a/src/fromhnsw/kgraph.rs
+++ b/src/fromhnsw/kgraph.rs
@@ -330,13 +330,13 @@ where
             mean_in_degree /= in_degrees.len() as f32;
         }
         //
-        println!("\n minimal graph statistics \n");
-        println!("\t max in degree : {:.2e}", max_in_degree);
-        println!("\t mean in degree : {:.2e}", mean_in_degree);
-        println!("\t max max range : {:.2e} ", max_max_r.to_f32().unwrap());
-        println!("\t min min range : {:.2e} ", min_min_r.to_f32().unwrap());
+        log::info!("\n minimal graph statistics \n");
+        log::info!("\t max in degree : {:.2e}", max_in_degree);
+        log::info!("\t mean in degree : {:.2e}", mean_in_degree);
+        log::info!("\t max max range : {:.2e} ", max_max_r.to_f32().unwrap());
+        log::info!("\t min min range : {:.2e} ", min_min_r.to_f32().unwrap());
         if quant.count() > 0 {
-            println!(
+            log::info!(
                 "min radius quantile at 0.05 : {:.2e} , 0.5 :  {:.2e}, 0.95 : {:.2e}, 0.99 : {:.2e}",
                 quant.query(0.05).unwrap().1,
                 quant.query(0.5).unwrap().1,
@@ -385,7 +385,7 @@ where
             nbng,
             max_nb_conn
         );
-        println!(
+        log::warn!(
             "init_from_hnsw_all: number of neighbours asked {} must be less than hnsw max_nb_connection : {} ",
             nbng, max_nb_conn
         );
@@ -449,7 +449,7 @@ where
                     p_id.0,
                     p_id.1
                 );
-                println!(
+                log::error!(
                     "kgraph_from_hnsw_all: graph will not be connected, isolated point at layer {}  , pos in layer : {} ",
                     p_id.0, p_id.1
                 );
@@ -490,8 +490,8 @@ where
     if mean_nbng < nbng as f64 {
         log::warn!(" mean number of neighbours obtained : {:.3e}", mean_nbng);
         log::warn!(" possibly use hnsw.set_keeping_pruned(true)");
-        println!(" mean number of neighbours obtained : {:.3e}", mean_nbng);
-        println!(" possibly use hnsw.set_keeping_pruned(true)");
+        log::warn!(" mean number of neighbours obtained : {:.3e}", mean_nbng);
+        log::warn!(" possibly use hnsw.set_keeping_pruned(true)");
     }
     //
     Ok(KGraph {
@@ -637,8 +637,8 @@ where
         );
     }
     if mean_nbng < nbng as f64 {
-        println!(" mean number of neighbours obtained : {:.3e}", mean_nbng);
-        println!(" possibly use hnsw.reset_keeping_pruned(true)");
+        log::warn!(" mean number of neighbours obtained : {:.3e}", mean_nbng);
+        log::warn!(" possibly use hnsw.reset_keeping_pruned(true)");
     }
     //
     Ok(KGraph {
@@ -702,7 +702,7 @@ mod tests {
         let knbn = 20;
         //
         log::debug!("test_full_hnsw");
-        println!("\n\n test_serial nb_elem {:?}", nb_elem);
+        log::debug!("\n\n test_serial nb_elem {:?}", nb_elem);
         //
         let data = gen_rand_data_f32(nb_elem, dim);
         let data_with_id: Vec<(&Vec<f32>, usize)> = data
@@ -727,7 +727,7 @@ mod tests {
         // make a test for dimension estimation
         let id = 10;
         let dimension = kgraph.intrinsic_dim_at_data_id(&id).unwrap();
-        println!("dimension around point : {}, dim = {:.3e}", id, dimension);
+        log::debug!("dimension around point : {}, dim = {:.3e}", id, dimension);
         log::info!(
             "\n dimension around point : {}, dim = {:.3e}",
             id,
@@ -742,7 +742,7 @@ mod tests {
             dimension.0,
             dimension.1
         );
-        println!(
+        log::debug!(
             "\n estimation of dimension : {:.3e}, sigma : {:.3e} ",
             dimension.0, dimension.1
         );
@@ -761,7 +761,7 @@ mod tests {
         let dim = 30;
         let knbn = 20;
         //
-        println!("\n\n test_serial nb_elem {:?}", nb_elem);
+        log::debug!("\n\n test_serial nb_elem {:?}", nb_elem);
         //
         let data = gen_rand_data_f32(nb_elem, dim);
         let data_with_id: Vec<(&Vec<f32>, usize)> = data.iter().zip(0..data.len()).collect();

--- a/src/fromhnsw/toripserer.rs
+++ b/src/fromhnsw/toripserer.rs
@@ -138,8 +138,8 @@ where
         let graph_projection = KGraphProjection::<f32>::new(self.hnsw, knbn, layer);
         let quant = graph_projection.get_projection_distance_quant();
         if quant.count() > 0 {
-            println!("\n\n projection distance from lower layers to upper layers");
-            println!(
+            log::debug!("\n\n projection distance from lower layers to upper layers");
+            log::debug!(
                 "\n quantile at 0.05 : {:.2e} , 0.5 :  {:.2e}, 0.95 : {:.2e}, 0.99 : {:.2e}",
                 quant.query(0.05).unwrap().1,
                 quant.query(0.5).unwrap().1,

--- a/src/graphlaplace.rs
+++ b/src/graphlaplace.rs
@@ -79,7 +79,7 @@ impl GraphLaplacian {
         let svd_res = svdapprox.direct_svd(svdmode);
         log::trace!("exited svd");
         if svd_res.is_err() {
-            println!("svd approximation failed");
+            log::error!("svd approximation failed");
             std::panic!();
         }
         self.check_norms(svd_res.as_ref().unwrap());
@@ -104,7 +104,7 @@ impl GraphLaplacian {
         let (nb_rows, nb_cols) = u.dim();
         for i in 0..nb_cols.min(3) {
             let norm = norm_frobenius_full(&u.column(i));
-            println!(" vector {} norm {:.2e} ", i, norm);
+            log::debug!(" vector {} norm {:.2e} ", i, norm);
         }
         log::trace!("end of check_norms");
     }
@@ -122,14 +122,14 @@ pub(crate) fn svd_f32(b: &mut Array2<f32>) -> Result<SvdResult<f32>, String> {
     };
     let slice_for_svd_opt = b.as_slice_mut();
     if slice_for_svd_opt.is_none() {
-        println!("direct_svd Matrix cannot be transformed into a slice : not contiguous or not in standard order");
+        log::error!("direct_svd Matrix cannot be transformed into a slice : not contiguous or not in standard order");
         return Err(String::from("not contiguous or not in standard order"));
     }
     // use divide conquer (calls lapack gesdd), faster but could use svd (lapack gesvd)
     log::trace!("direct_svd calling svddc driver");
     let res_svd_b = f32::svddc(layout, JobSvd::Some, slice_for_svd_opt.unwrap());
     if res_svd_b.is_err() {
-        println!("direct_svd, svddc failed");
+        log::error!("direct_svd, svddc failed");
     };
     // we have to decode res and fill in SvdApprox fields.
     // lax does encapsulte dgesvd (double) and sgesvd (single)  which returns U and Vt as vectors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ lazy_static! {
 // install a logger facility
 fn init_log() -> u64 {
     let _res = env_logger::try_init();
-    println!("\n ************** initializing logger *****************\n");
+    log::info!("\n ************** initializing logger *****************\n");
     1
 }
 

--- a/src/tools/dichotomy.rs
+++ b/src/tools/dichotomy.rs
@@ -76,7 +76,7 @@ mod tests {
         let f = |x: f32| x * x;
         //
         let beta = dichotomy_solver(true, f, 0., 5., 2.).unwrap();
-        println!("beta : {}", beta);
+        log::debug!("beta : {}", beta);
         assert!((beta - 2.0f32.sqrt()).abs() < 1.0E-4);
     } // test_dichotomy_inc
 
@@ -85,7 +85,7 @@ mod tests {
         let f = |x: f32| 1.0f32 / (x * x);
         //
         let beta = dichotomy_solver(false, f, 0.2, 5., 1. / 2.).unwrap();
-        println!("beta : {}", beta);
+        log::debug!("beta : {}", beta);
         assert!((beta - 2.0f32.sqrt()).abs() < 1.0E-4);
     } // test_dichotomy_dec
 }

--- a/src/tools/io.rs
+++ b/src/tools/io.rs
@@ -77,7 +77,7 @@ pub(crate) fn get_header_size(filepath: &Path) -> anyhow::Result<usize> {
             "fn get_header_size : could not open file {:?}",
             filepath.as_os_str()
         );
-        println!(
+        log::error!(
             "fn get_header_size : could not open file {:?}",
             filepath.as_os_str()
         );
@@ -132,7 +132,7 @@ where
             "ProcessingState reload_json : reload could not open file {:?}",
             filepath.as_os_str()
         );
-        println!(
+        log::error!(
             "directed_from_csv could not open file {:?}",
             filepath.as_os_str()
         );
@@ -182,7 +182,7 @@ where
             }
         } else {
             if record.len() != nb_fields {
-                println!(
+                log::error!(
                     "non constant number of fields at record {} first record has {}",
                     num_record, nb_fields
                 );

--- a/src/tools/kdumap.rs
+++ b/src/tools/kdumap.rs
@@ -73,15 +73,15 @@ where
                 node_params[*i] = param.1.clone();
             }
             (i, None) => {
-                println!("to_proba_edges , node rank {}, has no neighbour, use hnsw.set_keeping_pruned(true)", i);
+                log::error!("to_proba_edges , node rank {}, has no neighbour, use hnsw.set_keeping_pruned(true)", i);
                 log::error!("to_proba_edges , node rank {}, has no neighbour, use hnsw.set_keeping_pruned(true)", i);
                 std::process::exit(1);
             }
         };
     }
     // dump info on quantiles
-    println!("\n constructed initial space");
-    println!(
+    log::debug!("\n constructed initial space");
+    log::debug!(
         "\n scales quantile at 0.05 : {:.2e} , 0.5 :  {:.2e}, 0.95 : {:.2e}, 0.99 : {:.2e}",
         scale_q.query(0.05).unwrap().1,
         scale_q.query(0.5).unwrap().1,
@@ -89,7 +89,7 @@ where
         scale_q.query(0.99).unwrap().1
     );
     //
-    println!(
+    log::debug!(
         "\n edge weight quantile at 0.05 : {:.2e} , 0.5 :  {:.2e}, 0.95 : {:.2e}, 0.99 : {:.2e}",
         weight_q.query(0.05).unwrap().1,
         weight_q.query(0.5).unwrap().1,
@@ -97,14 +97,14 @@ where
         weight_q.query(0.99).unwrap().1
     );
     //
-    println!(
+    log::debug!(
         "\n perplexity quantile at 0.05 : {:.2e} , 0.5 :  {:.2e}, 0.95 : {:.2e}, 0.99 : {:.2e}",
         perplexity_q.query(0.05).unwrap().1,
         perplexity_q.query(0.5).unwrap().1,
         perplexity_q.query(0.95).unwrap().1,
         perplexity_q.query(0.99).unwrap().1
     );
-    println!();
+    log::debug!("");
     //
     NodeParams::new(node_params, max_nbng)
 } // end of construction of node params

--- a/src/tools/svdapprox.rs
+++ b/src/tools/svdapprox.rs
@@ -877,7 +877,7 @@ where
         };
         let slice_for_svd_opt = b.as_slice_mut();
         if slice_for_svd_opt.is_none() {
-            println!(
+            log::error!(
                 "direct_svd Matrix cannot be transformed into a slice : not contiguous or not in standard order"
             );
             return Err(String::from("not contiguous or not in standard order"));

--- a/src/utils/mnistio.rs
+++ b/src/utils/mnistio.rs
@@ -151,7 +151,7 @@ pub fn load_mnist_train_data(dname: &str) -> anyhow::Result<MnistData> {
     let image_path = PathBuf::from(image_fname.clone());
     let image_file_res = OpenOptions::new().read(true).open(&image_path);
     if image_file_res.is_err() {
-        println!("could not open image file : {:?}", image_fname);
+        log::error!("could not open image file : {:?}", image_fname);
         return Err(anyhow!("io error"));
     }
 
@@ -160,7 +160,7 @@ pub fn load_mnist_train_data(dname: &str) -> anyhow::Result<MnistData> {
     let label_path = PathBuf::from(label_fname.clone());
     let label_file_res = OpenOptions::new().read(true).open(&label_path);
     if label_file_res.is_err() {
-        println!("could not open label file : {:?}", label_fname);
+        log::error!("could not open label file : {:?}", label_fname);
         return Err(anyhow!("io error"));
     }
     //
@@ -173,7 +173,7 @@ pub fn load_mnist_test_data(dname: &str) -> anyhow::Result<MnistData> {
     let image_path = PathBuf::from(image_fname.clone());
     let image_file_res = OpenOptions::new().read(true).open(&image_path);
     if image_file_res.is_err() {
-        println!("could not open image file : {:?}", image_fname);
+        log::error!("could not open image file : {:?}", image_fname);
         return Err(anyhow!("io error"));
     }
 
@@ -182,7 +182,7 @@ pub fn load_mnist_test_data(dname: &str) -> anyhow::Result<MnistData> {
     let label_path = PathBuf::from(label_fname.clone());
     let label_file_res = OpenOptions::new().read(true).open(&label_path);
     if label_file_res.is_err() {
-        println!("could not open label file : {:?}", label_fname);
+        log::error!("could not open label file : {:?}", label_fname);
         return Err(anyhow!("io error"));
     }
     //


### PR DESCRIPTION
Replace println! with log macros for verbosity control

This PR replaces ~99 hardcoded println! statements with appropriate log macros (`log::info!`, `log::debug!`, `log::warn!`, `log::error!`), allowing users to control output verbosity via the `RUST_LOG`
environment variable.

## Changes

 - Library code now uses log macros instead of direct `println!`
 - Examples keep `println!` for expected user output
 - No breaking changes - already uses `env_logger`

## Usage

Users can now control verbosity:
 - `RUST_LOG=error` - only errors
 - `RUST_LOG=info` - info and above
 - `RUST_LOG=debug` - all output
 - `RUST_LOG=annembed=debug` - just this crate

---
Thank you @jean-pierreBoth for building this excellent dimensionality reduction library! I'm [wrapping annembed for use in Ruby](https://github.com/cpetersen/annembed-ruby) and needed finer control over output verbosity. This change follows Rust best practices while maintaining backward compatibility.
